### PR TITLE
Add stripe-connect-capital-offer component to connecttest

### DIFF
--- a/components/EmbeddedDashboard.tsx
+++ b/components/EmbeddedDashboard.tsx
@@ -35,6 +35,7 @@ import {
   ConnectAccountManagement,
   ConnectAppOnboarding,
   ConnectAppSettings,
+  ConnectCapitalOffer,
   ConnectCapitalOverview,
   ConnectDebugUIPreview,
   ConnectDebugUtils,
@@ -64,7 +65,8 @@ const componentPageList = [
   "Transactions",
   "Payouts",
   "Apps",
-  "Capital",
+  "Capital Offer",
+  "Capital Overview",
   "LPM",
   "Payment Details",
   "Account Onboarding",
@@ -205,7 +207,9 @@ StripeConnect.init({
             <ConnectAppSettings app="com.example.accounting-demo-app" />
           </>
         );
-      case "Capital":
+      case "Capital Offer":
+        return <ConnectCapitalOffer />;
+      case "Capital Overview":
         return <ConnectCapitalOverview />;
       case "LPM":
         return <ConnectPaymentMethodSettings />;

--- a/hooks/ConnectJsTypes.ts
+++ b/hooks/ConnectJsTypes.ts
@@ -104,6 +104,14 @@ export const ConnectAppOnboarding = ({ app }: { app: string }): JSX.Element => {
   return wrapper;
 };
 
+export const ConnectCapitalOffer = (): JSX.Element => {
+  const { wrapper } = useCreateComponent(
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+    "stripe-connect-capital-offer" as any,
+  );
+  return wrapper;
+};
+
 export const ConnectCapitalOverview = (): JSX.Element => {
   const { wrapper } = useCreateComponent(
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Connect-test is very useful for our prod bug bashes, so we want to add the `capital-offer` component to it.