### PR TITLE
enable configuring features param

### DIFF
--- a/clientsStorage/LocalStorageEntry.ts
+++ b/clientsStorage/LocalStorageEntry.ts
@@ -1,4 +1,5 @@
 import { Theme } from "../components/LocaleAndThemingOptions";
+import { FeaturesConfig } from "../utils/featuresConfigUtils";
 
 export class LocalStorageWrapper {
   private inMemoryItems: Record<string, string> = {};
@@ -76,4 +77,18 @@ export const getConnectJsSpecificCommitInStorage = (): string | undefined => {
 
 export const setConnectJsSpecificCommitInStorage = (commit: string) => {
   localStorageWrapper.setItem("connectjsspecificcommit", commit);
+};
+
+export const getFeaturesConfigInStorage = (): FeaturesConfig | undefined => {
+  const config = localStorageWrapper.getItem("featuresconfig");
+  if (config == null) return undefined;
+  return JSON.parse(config);
+};
+
+export const setFeaturesConfigInStorage = (config: FeaturesConfig) => {
+  localStorageWrapper.setItem("featuresconfig", JSON.stringify(config));
+};
+
+export const resetFeaturesConfigInStorage = () => {
+  localStorage.removeItem("featuresconfig");
 };

--- a/components/FeaturesConfigDialog.tsx
+++ b/components/FeaturesConfigDialog.tsx
@@ -1,26 +1,26 @@
 import {
   PrimaryButton,
   Stack,
+  StackItem,
+  Text,
   Dialog,
   IStackTokens,
   Checkbox,
+  DefaultButton,
 } from "@fluentui/react";
 import * as React from "react";
-import {
-  defaultFeaturesConfig,
-  featuresCache,
-  setFeaturesConfig,
-} from "../utils/featuresConfigUtils";
+import { defaultFeaturesConfig } from "../utils/featuresConfigUtils";
 import type {
   FeaturesConfig,
   Component,
   Feature,
 } from "../utils/featuresConfigUtils";
+import { getFeaturesConfigInStorage } from "../clientsStorage/LocalStorageEntry";
 
 type Props = {
-  accountId: string;
   onDismiss: () => void;
   onSave: (featuresConfig: FeaturesConfig) => void;
+  onReset: () => void;
 };
 
 function deepCopy(obj: Object) {
@@ -34,9 +34,7 @@ export const FeaturesConfigDialog: React.FC<Props> = (props) => {
     };
 
     const [featuresConfigState, setFeaturesConfigState] = React.useState(
-      deepCopy(
-        featuresCache[props.accountId]?.featuresConfig || defaultFeaturesConfig,
-      ),
+      getFeaturesConfigInStorage() || deepCopy(defaultFeaturesConfig),
     );
 
     return (
@@ -45,11 +43,13 @@ export const FeaturesConfigDialog: React.FC<Props> = (props) => {
           const component = c as Component;
           return (
             <Stack tokens={tokens} key={component}>
-              <Stack>{component}</Stack>
+              <StackItem>
+                <Text variant="large">{component}</Text>
+              </StackItem>
               {Object.keys(featuresConfigState[component]).map((f) => {
                 const feature = f as Feature;
                 return (
-                  <Stack key={feature}>
+                  <StackItem key={feature}>
                     <Checkbox
                       checked={featuresConfigState[component][feature]}
                       onChange={(_ev, val) => {
@@ -58,7 +58,7 @@ export const FeaturesConfigDialog: React.FC<Props> = (props) => {
                       }}
                       label={feature}
                     />
-                  </Stack>
+                  </StackItem>
                 );
               })}
             </Stack>
@@ -67,12 +67,17 @@ export const FeaturesConfigDialog: React.FC<Props> = (props) => {
         <PrimaryButton
           onClick={() => {
             props.onSave(featuresConfigState);
-            setFeaturesConfig(props.accountId, featuresConfigState);
-            props.onDismiss();
           }}
         >
           Save
         </PrimaryButton>
+        <DefaultButton
+          onClick={() => {
+            props.onReset();
+          }}
+        >
+          Reset
+        </DefaultButton>
       </Stack>
     );
   };

--- a/components/FeaturesConfigDialog.tsx
+++ b/components/FeaturesConfigDialog.tsx
@@ -1,0 +1,85 @@
+import {
+  PrimaryButton,
+  Stack,
+  Dialog,
+  IStackTokens,
+  Checkbox,
+} from "@fluentui/react";
+import * as React from "react";
+import {
+  defaultFeaturesConfig,
+  featuresCache,
+  setFeaturesConfig,
+} from "../utils/featuresConfigUtils";
+import type {
+  FeaturesConfig,
+  Component,
+  Feature,
+} from "../utils/featuresConfigUtils";
+
+type Props = {
+  accountId: string;
+  onDismiss: () => void;
+  onSave: (featuresConfig: FeaturesConfig) => void;
+};
+
+function deepCopy(obj: Object) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+export const FeaturesConfigDialog: React.FC<Props> = (props) => {
+  const renderContent = () => {
+    const tokens: IStackTokens = {
+      childrenGap: "15px",
+    };
+
+    const [featuresConfigState, setFeaturesConfigState] = React.useState(
+      deepCopy(
+        featuresCache[props.accountId]?.featuresConfig || defaultFeaturesConfig,
+      ),
+    );
+
+    return (
+      <Stack tokens={tokens}>
+        {Object.keys(featuresConfigState).map((c) => {
+          const component = c as Component;
+          return (
+            <Stack tokens={tokens} key={component}>
+              <Stack>{component}</Stack>
+              {Object.keys(featuresConfigState[component]).map((f) => {
+                const feature = f as Feature;
+                return (
+                  <Stack key={feature}>
+                    <Checkbox
+                      checked={featuresConfigState[component][feature]}
+                      onChange={(_ev, val) => {
+                        featuresConfigState[component][feature] = val || false;
+                        setFeaturesConfigState({ ...featuresConfigState });
+                      }}
+                      label={feature}
+                    />
+                  </Stack>
+                );
+              })}
+            </Stack>
+          );
+        })}
+        <PrimaryButton
+          onClick={() => {
+            props.onSave(featuresConfigState);
+            setFeaturesConfig(props.accountId, featuresConfigState);
+            props.onDismiss();
+          }}
+        >
+          Save
+        </PrimaryButton>
+      </Stack>
+    );
+  };
+
+  return (
+    <Dialog hidden={false} minWidth={600} onDismiss={props.onDismiss}>
+      {renderContent()}
+    </Dialog>
+  );
+};

--- a/components/LocaleAndThemingOptions.tsx
+++ b/components/LocaleAndThemingOptions.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, Stack } from "@fluentui/react";
+import { DefaultButton, Dropdown, PrimaryButton, Stack } from "@fluentui/react";
 import * as React from "react";
 import { createTheme, loadTheme } from "@fluentui/react";
 import {
@@ -6,11 +6,14 @@ import {
   getConnectJSSourceInStorage,
   getLocaleInStorage,
   getThemeInStorage,
+  resetFeaturesConfigInStorage,
   setConnectJSSourceInStorage,
   setConnectJsSpecificCommitInStorage,
+  setFeaturesConfigInStorage,
   setLocaleInStorage,
   setThemeInStorage,
 } from "../clientsStorage/LocalStorageEntry";
+import { FeaturesConfigDialog } from "./FeaturesConfigDialog";
 
 export type Theme = "Light" | "Dark";
 
@@ -105,11 +108,37 @@ export const LocaleAndThemingOptions: React.FC = () => {
   const [currentConnectJSSource, setCurrentConnectJSSource] =
     React.useState<string>(getConnectJSSourceInStorage());
 
+  const [showFeaturesConfigDialog, setShowFeaturesConfigDialog] =
+    React.useState<boolean>(false);
+
   React.useEffect(() => {}, [currentTheme]);
+
+  const renderDialog = () => {
+    return (
+      <>
+        {showFeaturesConfigDialog && (
+          <FeaturesConfigDialog
+            onDismiss={() => {
+              setShowFeaturesConfigDialog(false);
+            }}
+            onSave={(config) => {
+              setFeaturesConfigInStorage(config);
+              window.location.reload();
+            }}
+            onReset={() => {
+              resetFeaturesConfigInStorage();
+              window.location.reload();
+            }}
+          />
+        )}
+      </>
+    );
+  };
 
   return (
     <div>
       <div style={{ position: "fixed", bottom: "0", right: "0" }}>
+        {renderDialog()}
         <Stack horizontal>
           <Dropdown
             options={[
@@ -198,6 +227,9 @@ export const LocaleAndThemingOptions: React.FC = () => {
               window.location.reload();
             }}
           />
+          <DefaultButton onClick={() => setShowFeaturesConfigDialog(true)}>
+            Change component features config
+          </DefaultButton>
         </Stack>
       </div>
     </div>

--- a/hooks/fetchClientSecret.ts
+++ b/hooks/fetchClientSecret.ts
@@ -1,9 +1,12 @@
 import {
-  clearFeaturesConfig,
+  FeaturesConfig,
   getAccountSessionComponentParamWithFeatures,
 } from "../utils/featuresConfigUtils";
 
-export const fetchClientSecret = async (accountId: string): Promise<string> => {
+export const fetchClientSecret = async (
+  accountId: string,
+  featureConfig: FeaturesConfig | undefined,
+): Promise<string> => {
   // Original list:
   /**
    "account_management" => @account_permissions,
@@ -57,22 +60,12 @@ export const fetchClientSecret = async (accountId: string): Promise<string> => {
     },
     payment_details: {
       enabled: true,
-      features: {
-        refund_management: true,
-        dispute_management: true,
-        capture_payments: true,
-      },
     },
     payment_method_settings: {
       enabled: true,
     },
     payments: {
       enabled: true,
-      features: {
-        refund_management: true,
-        dispute_management: true,
-        capture_payments: true,
-      },
     },
     payouts_list: {
       enabled: true,
@@ -93,8 +86,8 @@ export const fetchClientSecret = async (accountId: string): Promise<string> => {
       body: JSON.stringify({
         accountId: accountId,
         components: getAccountSessionComponentParamWithFeatures(
-          accountId,
           defaultComponents,
+          featureConfig,
         ),
       }),
     });
@@ -107,7 +100,6 @@ export const fetchClientSecret = async (accountId: string): Promise<string> => {
       } catch (e) {
         // ignore
       }
-      clearFeaturesConfig(accountId);
       throw new Error(
         `Unexpected response code ${apiResponse.status}. ${
           errorText ? `Internal error: ${errorText}` : ""

--- a/hooks/fetchClientSecret.ts
+++ b/hooks/fetchClientSecret.ts
@@ -1,4 +1,89 @@
+import {
+  clearFeaturesConfig,
+  getAccountSessionComponentParamWithFeatures,
+} from "../utils/featuresConfigUtils";
+
 export const fetchClientSecret = async (accountId: string): Promise<string> => {
+  // Original list:
+  /**
+   "account_management" => @account_permissions,
+    "account_onboarding" => @account_permissions,
+    "app_onboarding" => @app_onboarding_permissions,
+    "app_install" => @app_onboarding_permissions,
+    "app_settings" => @app_settings_permissions,
+    "balances" => @payout_permissions,
+    "capital_overview" => @capital_overview_permissions,
+    "capital_offer" => @capital_offer_permissions,
+    "notification_banner" => @account_permissions,
+    "instant_payouts" => @instant_payouts_permissions,
+    "payment_details" => @payment_permissions,
+    "payment_method_settings" => @payment_method_settings_permissions,
+    "payments" => @payment_permissions,
+    "payouts_list" => @payout_permissions,
+    "payouts" => @payout_permissions,
+    "transactions_list" => @transactions_permissions
+  */
+
+  const defaultComponents = {
+    account_management: {
+      enabled: true,
+    },
+    account_onboarding: {
+      enabled: true,
+    },
+    app_onboarding: {
+      enabled: true,
+    },
+    app_install: {
+      enabled: true,
+    },
+    app_settings: {
+      enabled: true,
+    },
+    balances: {
+      enabled: true,
+    },
+    capital_overview: {
+      enabled: true,
+    },
+    capital_offer: {
+      enabled: true,
+    },
+    notification_banner: {
+      enabled: true,
+    },
+    instant_payouts: {
+      enabled: true,
+    },
+    payment_details: {
+      enabled: true,
+      features: {
+        refund_management: true,
+        dispute_management: true,
+        capture_payments: true,
+      },
+    },
+    payment_method_settings: {
+      enabled: true,
+    },
+    payments: {
+      enabled: true,
+      features: {
+        refund_management: true,
+        dispute_management: true,
+        capture_payments: true,
+      },
+    },
+    payouts_list: {
+      enabled: true,
+    },
+    payouts: {
+      enabled: true,
+    },
+    transactions_list: {
+      enabled: true,
+    },
+  };
   try {
     const apiResponse = await fetch("/api/create-account-session", {
       method: "POST",
@@ -7,6 +92,10 @@ export const fetchClientSecret = async (accountId: string): Promise<string> => {
       },
       body: JSON.stringify({
         accountId: accountId,
+        components: getAccountSessionComponentParamWithFeatures(
+          accountId,
+          defaultComponents,
+        ),
       }),
     });
 
@@ -18,6 +107,7 @@ export const fetchClientSecret = async (accountId: string): Promise<string> => {
       } catch (e) {
         // ignore
       }
+      clearFeaturesConfig(accountId);
       throw new Error(
         `Unexpected response code ${apiResponse.status}. ${
           errorText ? `Internal error: ${errorText}` : ""

--- a/hooks/useConnectJsInit.tsx
+++ b/hooks/useConnectJsInit.tsx
@@ -16,6 +16,11 @@ import {
 } from "../clientsStorage/LocalStorageEntry";
 import { assertNever } from "@fluentui/react";
 import { loadConnect } from "@stripe/connect-js/pure";
+import {
+  FeaturesConfig,
+  accountSessionFeaturesUpToDate,
+  setAccountSessionFeaturesUpToDate,
+} from "../utils/featuresConfigUtils";
 
 const injectScript = (): HTMLScriptElement => {
   const script = document.createElement("script");
@@ -95,15 +100,21 @@ const connectJsCache: Record<
   }
 > = {};
 
-export const useConnectJSInit = (accountId: string) => {
+export const useConnectJSInit = (
+  accountId: string,
+  featuresConfig?: FeaturesConfig,
+) => {
   return useQuery<
     {
       stripeConnectInstance: StripeConnectInstance;
       stripeConnectWrapper: StripeConnectWrapper;
     },
     Error
-  >(["ConnectJSInit", accountId], async () => {
-    if (connectJsCache[accountId]) {
+  >(["ConnectJSInit", accountId, featuresConfig], async () => {
+    if (
+      connectJsCache[accountId] &&
+      accountSessionFeaturesUpToDate(accountId)
+    ) {
       return connectJsCache[accountId];
     }
 
@@ -158,6 +169,8 @@ export const useConnectJSInit = (accountId: string) => {
       stripeConnectInstance: instance,
       stripeConnectWrapper: stripeConnect,
     };
+
+    setAccountSessionFeaturesUpToDate(accountId);
 
     return {
       stripeConnectInstance: instance,

--- a/pages/api/create-account-session.ts
+++ b/pages/api/create-account-session.ts
@@ -9,83 +9,11 @@ export default async function handler(
     const accountId: string = req.body.accountId;
     console.log("Id is ", accountId);
 
-    // Original list:
-    /**
-       "account_management" => @account_permissions,
-        "account_onboarding" => @account_permissions,
-        "app_onboarding" => @app_onboarding_permissions,
-        "app_install" => @app_onboarding_permissions,
-        "app_settings" => @app_settings_permissions,
-        "balances" => @payout_permissions,
-        "capital_overview" => @capital_overview_permissions,
-        "capital_offer" => @capital_offer_permissions,
-        "notification_banner" => @account_permissions,
-        "instant_payouts" => @instant_payouts_permissions,
-        "payment_details" => @payment_permissions,
-        "payment_method_settings" => @payment_method_settings_permissions,
-        "payments" => @payment_permissions,
-        "payouts_list" => @payout_permissions,
-        "payouts" => @payout_permissions,
-        "transactions_list" => @transactions_permissions
-     */
-
-    // Specify the API version to include the beta header
-    const accountSessionResponse = await StripeClient.accountSessions.create(
-      {
-        account: accountId,
-        // read_only: true, // private param
-        components: {
-          account_management: {
-            enabled: true,
-          },
-          account_onboarding: {
-            enabled: true,
-          },
-          app_onboarding: {
-            enabled: true,
-          },
-          app_install: {
-            enabled: true,
-          },
-          app_settings: {
-            enabled: true,
-          },
-          balances: {
-            enabled: true,
-          },
-          capital_overview: {
-            enabled: true,
-          },
-          capital_offer: {
-            enabled: true,
-          },
-          notification_banner: {
-            enabled: true,
-          },
-          instant_payouts: {
-            enabled: true,
-          },
-          payment_details: {
-            enabled: true,
-          },
-          payment_method_settings: {
-            enabled: true,
-          },
-          payments: {
-            enabled: true,
-          },
-          payouts_list: {
-            enabled: true,
-          },
-          payouts: {
-            enabled: true,
-          },
-          transactions_list: {
-            enabled: true,
-          },
-        },
-      } as any, // Bypass type since we have private options here
-    );
+    const accountSessionResponse = await StripeClient.accountSessions.create({
+      account: accountId,
+      // read_only: true, // private param
+      components: req.body.components,
+    });
 
     (accountSessionResponse as any).publicKey =
       process.env.NEXT_PUBLIC_stripe_public_key;

--- a/utils/featuresConfigUtils.ts
+++ b/utils/featuresConfigUtils.ts
@@ -14,47 +14,18 @@ export const defaultFeaturesConfig = {
 };
 
 export type FeaturesConfig = typeof defaultFeaturesConfig;
-
-export const featuresCache: {
-  [accountId: string]: { featuresConfig: FeaturesConfig; updated: boolean };
-} = {};
-
 export type Component = keyof typeof defaultFeaturesConfig;
 export type Feature = keyof typeof defaultFeaturesConfig[Component];
 
-export function accountSessionFeaturesUpToDate(accountId: string) {
-  if (!(accountId in featuresCache)) return true;
-  return featuresCache[accountId].updated;
-}
-
-export function setAccountSessionFeaturesUpToDate(accountId: string) {
-  if (!(accountId in featuresCache)) return;
-  featuresCache[accountId].updated = true;
-}
-
 export function getAccountSessionComponentParamWithFeatures<
   T extends Stripe.AccountSessionCreateParams.Components,
->(accountId: string, defaultParam: T) {
-  if (!(accountId in featuresCache)) return defaultParam;
+>(defaultParam: T, featuresConfig: FeaturesConfig | undefined) {
+  if (featuresConfig === undefined) return defaultParam;
   const param = defaultParam;
-  const featuresConfig = featuresCache[accountId].featuresConfig;
   let comp: keyof FeaturesConfig;
   for (comp in featuresConfig) {
     // @ts-expect-error Property 'features' does not exist on type 'Payments | PaymentDetails'.
     param[comp].features = featuresConfig[comp];
   }
   return param;
-}
-
-export function setFeaturesConfig(
-  accountId: string,
-  featuresConfig: FeaturesConfig,
-) {
-  featuresCache[accountId] = { featuresConfig, updated: false };
-}
-
-export function clearFeaturesConfig(accountId: string) {
-  if (accountId in featuresCache) {
-    delete featuresCache[accountId];
-  }
 }

--- a/utils/featuresConfigUtils.ts
+++ b/utils/featuresConfigUtils.ts
@@ -1,0 +1,60 @@
+import Stripe from "stripe";
+
+export const defaultFeaturesConfig = {
+  payments: {
+    refund_management: true,
+    dispute_management: true,
+    capture_payments: true,
+  },
+  payment_details: {
+    refund_management: true,
+    dispute_management: true,
+    capture_payments: true,
+  },
+};
+
+export type FeaturesConfig = typeof defaultFeaturesConfig;
+
+export const featuresCache: {
+  [accountId: string]: { featuresConfig: FeaturesConfig; updated: boolean };
+} = {};
+
+export type Component = keyof typeof defaultFeaturesConfig;
+export type Feature = keyof typeof defaultFeaturesConfig[Component];
+
+export function accountSessionFeaturesUpToDate(accountId: string) {
+  if (!(accountId in featuresCache)) return true;
+  return featuresCache[accountId].updated;
+}
+
+export function setAccountSessionFeaturesUpToDate(accountId: string) {
+  if (!(accountId in featuresCache)) return;
+  featuresCache[accountId].updated = true;
+}
+
+export function getAccountSessionComponentParamWithFeatures<
+  T extends Stripe.AccountSessionCreateParams.Components,
+>(accountId: string, defaultParam: T) {
+  if (!(accountId in featuresCache)) return defaultParam;
+  const param = defaultParam;
+  const featuresConfig = featuresCache[accountId].featuresConfig;
+  let comp: keyof FeaturesConfig;
+  for (comp in featuresConfig) {
+    // @ts-expect-error Property 'features' does not exist on type 'Payments | PaymentDetails'.
+    param[comp].features = featuresConfig[comp];
+  }
+  return param;
+}
+
+export function setFeaturesConfig(
+  accountId: string,
+  featuresConfig: FeaturesConfig,
+) {
+  featuresCache[accountId] = { featuresConfig, updated: false };
+}
+
+export function clearFeaturesConfig(accountId: string) {
+  if (accountId in featuresCache) {
+    delete featuresCache[accountId];
+  }
+}


### PR DESCRIPTION
Added a dialog to configure features for account sessions, so that we test turning on/off features.

Saving the feature config for an account in the dialog creates a new account session with the updated features; the feature config each account is currently using (unless they are never configured) are stored in a JS object.

https://github.com/jogonzal/jorgeconnectplatform/assets/110323300/942d1b14-e78a-475b-9f02-94b2bbcdf452

